### PR TITLE
Remove 'simply' and 'just' from the Contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Within each language folder, you'll find the following:
 - A README
 - A list of program files.
 
-Now, the program files are self-explanatory. Each one just maps to an ongoing project
+Now, each program file maps to an ongoing project
 that you can find in the General Rules section. As for the README, it contains a list
 of the program files that link to existing articles on The Renegade Coder.
 In addition, the README contains links to language references and a list of fun facts.
@@ -48,7 +48,7 @@ Thanks for keeping this repository inclusive!
 
 ## General Rules
 
-If you wish to contribute, simply fork the repo and make a pull request
+If you wish to contribute, [fork](https://help.github.com/articles/fork-a-repo) the repo and make a pull request
 with your changes. Ideally, your contribution should be to existing projects,
 but you're welcome to add new snippets.
 


### PR DESCRIPTION
## Notes

For the sake of being inclusive, I think words like "just" and "simply" can be off-putting, especially to people who are new. It could make them think they should know these things but don't, which can be discouraging.

I always say, let the reader decide if it's easy.

I may have messed up the text formatting a little.