### PR TITLE
Fixes PowerShell README and renames hello-world.ps1 to Hello-World.ps1

### DIFF
--- a/archive/p/powershell/Hello-World.ps1
+++ b/archive/p/powershell/Hello-World.ps1
@@ -1,0 +1,1 @@
+Write-Host "Hello, World!"

--- a/archive/p/powershell/README.md
+++ b/archive/p/powershell/README.md
@@ -17,5 +17,5 @@ Welcome to Sample Programs in PowerShell!
 - [PowerShell Documentation](https://docs.microsoft.com/en-us/powershell/)
 - [Try It Online: PowerShell](https://tio.run/#powershell)
 
-[1]: ..\blob\master\archive\p\powershell\Hello-World.ps1
-[2]: ..\blob\master\archive\p\powershell\Reverse-String.ps1
+[1]: ../blob/master/archive/p/powershell/Hello-World.ps1
+[2]: ../blob/master/archive/p/powershell/Reverse-String.ps1

--- a/archive/p/powershell/README.md
+++ b/archive/p/powershell/README.md
@@ -17,5 +17,5 @@ Welcome to Sample Programs in PowerShell!
 - [PowerShell Documentation](https://docs.microsoft.com/en-us/powershell/)
 - [Try It Online: PowerShell](https://tio.run/#powershell)
 
-[1]: ../blob/master/archive/p/powershell/Hello-World.ps1
-[2]: ../blob/master/archive/p/powershell/Reverse-String.ps1
+[1]: ./Hello-World.ps1
+[2]: ./Reverse-String.ps1

--- a/archive/p/powershell/hello-world.ps1
+++ b/archive/p/powershell/hello-world.ps1
@@ -1,1 +1,0 @@
-Write-Host "Hello, World!"


### PR DESCRIPTION
- [ ] I would **NOT** like credit for my contribution in the article (credit will be included otherwise)
- [x] I named the pull request using `<Sample Program> in <Language>` format
- [x] I created/updated the language README
  - [ ] I added the sample program name to the README
  - [ ] I added fun facts (i.e. debut, developer, typing, etc.)
  - [x] I added reference link(s) to the README

## Notes

This PR fixes the link issue with the README in the PowerShell directory as well as renames `hello-world.ps1` to `Hello-World.ps1` as per PowerShell standards.
